### PR TITLE
Add function for getting "Up Next" books from a user's "To Read" list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,13 @@ print(result)
   [
     {
         "title": "The Murder After the Night Before",
-        "book_id": "38cb5b56-23f1-48fd-b4b3-a80e07a19775"
+        "book_id": "38cb5b56-23f1-48fd-b4b3-a80e07a19775",
+        "authors": ["Katy Brent"]
     },
     {
         "title": "The Graces",
-        "book_id": "653b54b3-a79d-4c2e-ae40-eae281a91315"
+        "book_id": "653b54b3-a79d-4c2e-ae40-eae281a91315",
+        "authors": ["Laure Eve"]
     }
 ]
 

--- a/storygraph_api/parse/user_parser.py
+++ b/storygraph_api/parse/user_parser.py
@@ -5,8 +5,10 @@ from bs4 import BeautifulSoup
 class UserParser:
     @staticmethod
     @parsing_exception 
-    def parse_html(html):
+    def parse_html(html, id_enclosure=None):
         soup = BeautifulSoup(html, 'html.parser')
+        if id_enclosure:
+            soup = soup.find_all('div', attrs={"id": id_enclosure})[0]
         books_list = []
         books = soup.find_all('div', class_="book-title-author-and-series")
         for book in books:
@@ -28,6 +30,11 @@ class UserParser:
     def to_read(uname, cookie):
         content = UserScraper.to_read(uname,cookie)
         return UserParser.parse_html(content)
+
+    @staticmethod
+    def up_next(uname, cookie):
+        content = UserScraper.to_read(uname, cookie)
+        return UserParser.parse_html(content, "up-next-section")
 
     @staticmethod
     def books_read(uname, cookie):

--- a/storygraph_api/parse/user_parser.py
+++ b/storygraph_api/parse/user_parser.py
@@ -15,7 +15,6 @@ class UserParser:
             a_list = book.find_all('a')
             authors = []
             for a in a_list:
-                print(f"a link: {a['href']}")
                 if a['href'].startswith("/books/"):
                     title = a.text.strip()
                     book_id = a['href'].split('/')[-1]

--- a/storygraph_api/parse/user_parser.py
+++ b/storygraph_api/parse/user_parser.py
@@ -12,11 +12,19 @@ class UserParser:
         books_list = []
         books = soup.find_all('div', class_="book-title-author-and-series")
         for book in books:
-            title = book.find('a').text.strip()
-            book_id = book.find('a')['href'].split('/')[-1]
+            a_list = book.find_all('a')
+            authors = []
+            for a in a_list:
+                print(f"a link: {a['href']}")
+                if a['href'].startswith("/books/"):
+                    title = a.text.strip()
+                    book_id = a['href'].split('/')[-1]
+                if a['href'].startswith("/authors/"):
+                    authors.append(a.text.strip())
             books_list.append({
                 'title': title,
-                'book_id': book_id
+                'book_id': book_id,
+                'author': authors
                 })
         data = list({(book['title'], book['book_id']): book for book in books_list}.values())
         return data

--- a/storygraph_api/parse/user_parser.py
+++ b/storygraph_api/parse/user_parser.py
@@ -23,7 +23,7 @@ class UserParser:
             books_list.append({
                 'title': title,
                 'book_id': book_id,
-                'author': authors
+                'authors': authors
                 })
         data = list({(book['title'], book['book_id']): book for book in books_list}.values())
         return data

--- a/storygraph_api/parse/user_parser.py
+++ b/storygraph_api/parse/user_parser.py
@@ -3,6 +3,20 @@ from storygraph_api.exception_handler import parsing_exception
 from bs4 import BeautifulSoup
 
 class UserParser:
+
+    @staticmethod
+    def _book_covers(soup):
+        book_to_cover = dict()
+        links = soup.find_all('a')
+        for link in links:
+            if not link['href'].startswith('/books/'):
+                continue
+            img = link.find('img')
+            if not img:
+                continue
+            book_to_cover[link['href'].split('/')[-1]] = img['src']
+        return book_to_cover
+
     @staticmethod
     @parsing_exception 
     def parse_html(html, id_enclosure=None):
@@ -11,6 +25,7 @@ class UserParser:
             soup = soup.find_all('div', attrs={"id": id_enclosure})[0]
         books_list = []
         books = soup.find_all('div', class_="book-title-author-and-series")
+        covers = UserParser._book_covers(soup)
         for book in books:
             a_list = book.find_all('a')
             authors = []
@@ -23,7 +38,8 @@ class UserParser:
             books_list.append({
                 'title': title,
                 'book_id': book_id,
-                'authors': authors
+                'authors': authors,
+                'cover': covers[book_id]
                 })
         data = list({(book['title'], book['book_id']): book for book in books_list}.values())
         return data

--- a/storygraph_api/users_client.py
+++ b/storygraph_api/users_client.py
@@ -14,6 +14,11 @@ class User:
         return json.dumps(data,indent=4)
 
     @handle_exceptions
+    def up_next(self, uname, cookie):
+        data = UserParser.up_next(uname,cookie)
+        return json.dumps(data,indent=4)
+
+    @handle_exceptions
     def books_read(self,uname,cookie):
         data = UserParser.books_read(uname,cookie)
         return json.dumps(data,indent=4)


### PR DESCRIPTION
This adds the ability to parse the "Up Next" section by searching for the `up-next-section` div ID.

It also adds author parsing to the read/to_read/up_next parsing. This is returned along with the title and book_id as a list of authors for that title. I did this because the Book() API is broken, and the only reason I was using it was to collect Author names. But also, Storygraph appears to have some scraper protection specifically on their /books/ urls that blocked me while the user book lists were unaffected.

This change resolved those issues for me. 