### PR TITLE
Update user_parser.py

### DIFF
--- a/storygraph_api/parse/user_parser.py
+++ b/storygraph_api/parse/user_parser.py
@@ -5,16 +5,25 @@ from bs4 import BeautifulSoup
 class UserParser:
     @staticmethod
     @parsing_exception 
-    def parse_html(html):
+    def parse_html(html, id_enclosure=None):
         soup = BeautifulSoup(html, 'html.parser')
+        if id_enclosure:
+            soup = soup.find_all('div', attrs={"id": id_enclosure})[0]
         books_list = []
         books = soup.find_all('div', class_="book-title-author-and-series")
         for book in books:
-            title = book.find('a').text.strip()
-            book_id = book.find('a')['href'].split('/')[-1]
+            a_list = book.find_all('a')
+            authors = []
+            for a in a_list:
+                if a['href'].startswith("/books/"):
+                    title = a.text.strip()
+                    book_id = a['href'].split('/')[-1]
+                if a['href'].startswith("/authors/"):
+                    authors.append(a.text.strip())
             books_list.append({
                 'title': title,
-                'book_id': book_id
+                'book_id': book_id,
+                'authors': authors
                 })
         data = list({(book['title'], book['book_id']): book for book in books_list}.values())
         return data
@@ -28,6 +37,11 @@ class UserParser:
     def to_read(uname, cookie):
         content = UserScraper.to_read(uname,cookie)
         return UserParser.parse_html(content)
+
+    @staticmethod
+    def up_next(uname, cookie):
+        content = UserScraper.to_read(uname, cookie)
+        return UserParser.parse_html(content, "up-next-section")
 
     @staticmethod
     def books_read(uname, cookie):


### PR DESCRIPTION
This adds the ability to parse the "Up Next" section by searching for the up-next-section div ID.

It also adds author parsing to the read/to_read/up_next parsing. This is returned along with the title and book_id as a list of authors for that title. I did this because the Book() API is broken, and the only reason I was using it was to collect Author names. But also, Storygraph appears to have some scraper protection specifically on their /books/ urls that blocked me while the user book lists were unaffected.

This change resolved those issues for me.